### PR TITLE
Fix race in ReadWriteLock.(try)acquireWrite, and add a partial test case

### DIFF
--- a/concurrent-extra.cabal
+++ b/concurrent-extra.cabal
@@ -85,6 +85,7 @@ test-suite test-concurrent-extra
                , stm                  >= 2.1.2.1 && < 2.5
                , unbounded-delays     >= 0.1     && < 0.2
                , HUnit                >= 1.2.2   && < 1.3
+               , random               >= 1.0     && < 1.1
                , test-framework       >= 0.2.4   && < 0.9
                , test-framework-hunit >= 0.2.4   && < 0.4
 


### PR DESCRIPTION
For me, this fixes issue #8. Previously, the `Write` -> `Write` state change in `acquireWrite` was accomplished by the sequence

``` haskell
putMVar state st
Lock.acquire writeLock
void $ swapMVar state Write
```

As I see it, this is problematic because there is nothing preventing a reader slip in between the `putMVar` and acquiring the write lock (well, the reader wouldn't even care if the write lock was acquired), so I guess the `void` threw away a `Read` state sometimes. There was a similar problem with `tryAcquireWrite`, which should be fixed as well.

I also added a new test case for this, but it's not in a good state currently: The test is recognized as `passed` even when the bug strikes. The only way to know is to have a look at the test's log file. I included it anyway because at least it's no worse than before.
