### PR TITLE
Update concurrent-extra.cabal - bump up async bounds

### DIFF
--- a/concurrent-extra.cabal
+++ b/concurrent-extra.cabal
@@ -86,6 +86,6 @@ test-suite test-concurrent-extra
                , random               >= 1.0     && < 1.2
                , test-framework       >= 0.2.4   && < 0.9
                , test-framework-hunit >= 0.2.4   && < 0.4
-               , async                >= 2.0     && < 2.1
+               , async                >= 2.0     && < 2.2
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Bump up bounds for `async` - tests pass on my local machine with this change.

This should allow the package to be added to stackage - I am able to build successfully with lts-5.17 (current LTS release at the time of writing).
